### PR TITLE
Drop users table to prepare for devise install

### DIFF
--- a/db/migrate/20220227012707_drop_users.rb
+++ b/db/migrate/20220227012707_drop_users.rb
@@ -1,0 +1,18 @@
+class DropUsers < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :users do
+      t.string "name"
+      t.string "email"
+      t.string "password_digest"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.boolean "track_alcohols", default: false
+      t.boolean "track_caffeines", default: false
+      t.boolean "track_exercises", default: false
+      t.boolean "track_late_meals", default: false
+      t.boolean "track_morning_suns", default: false
+      t.boolean "track_naps", default: false
+      t.boolean "track_relaxes", default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_153634) do
+ActiveRecord::Schema.define(version: 2022_02_27_012707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,21 +48,6 @@ ActiveRecord::Schema.define(version: 2019_05_31_153634) do
     t.integer "room_temperature"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "users", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "password_digest"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "track_alcohols", default: false
-    t.boolean "track_caffeines", default: false
-    t.boolean "track_exercises", default: false
-    t.boolean "track_late_meals", default: false
-    t.boolean "track_morning_suns", default: false
-    t.boolean "track_naps", default: false
-    t.boolean "track_relaxes", default: false
   end
 
 end


### PR DESCRIPTION
Before I start actually generating users, let's drop the users table to make the switch to Devise easier. It's always a pain to do it after-the-fact. Devise will generate a users table. 